### PR TITLE
Exclude option for aggregate and volumes

### DIFF
--- a/check_cdot_aggr.pl
+++ b/check_cdot_aggr.pl
@@ -100,11 +100,13 @@ while(defined($next)){
 
     foreach my $aggr (@result){
 
-        next if exists $Excludelist{$aggr_name};
+        
 
         my $aggr_name = $aggr->child_get_string("aggregate-name");
 
         unless($aggr_name =~ m/^aggr0_/){
+
+            next if exists $Excludelist{$aggr_name};
 
             my $space = $aggr->child_get("aggr-space-attributes");
             my $percent = $space->child_get_int("percent-used-capacity");

--- a/check_cdot_aggr.pl
+++ b/check_cdot_aggr.pl
@@ -26,9 +26,13 @@ GetOptions(
     'warning=i'  => \my $Warning,
     'critical=i' => \my $Critical,
     'aggr=s'     => \my $Aggr,
-    'perf'     => \my $perf,
+    'perf'       => \my $perf,
+    'exclude=s'  => \my @excludelistarray,
     'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
+
+my %Excludelist;
+@Excludelist{@excludelistarray}=();
 
 sub Error {
     print "$0: " . $_[0] . "\n";
@@ -95,6 +99,8 @@ while(defined($next)){
     my @result = $aggrs->children_get();
 
     foreach my $aggr (@result){
+
+        next if exists $Excludelist{$aggr_name};
 
         my $aggr_name = $aggr->child_get_string("aggregate-name");
 
@@ -192,6 +198,10 @@ Flag for performance data output
 =item --aggr
 
 Check only specific aggregate
+
+=item --exclude
+
+Optional: The name of an aggregate that has to be excluded from the checks (multiple exclude item for multiple aggregates)
 
 =item -help
 

--- a/check_cdot_volume.pl
+++ b/check_cdot_volume.pl
@@ -28,8 +28,12 @@ GetOptions(
     'inode-critical=i' => \my $InodeCritical,
     'perf'     => \my $perf,
     'volume=s'   => \my $Volume,
+    'exclude=s'	 =>	\my @excludelistarray,
     'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
+
+my %Excludelist;
+@Excludelist{@excludelistarray}=();
 
 sub Error {
     print "$0: " . $_[0] . "\n";
@@ -124,6 +128,8 @@ while(defined($next)){
 	    
 	        my $vol_info = $vol->child_get("volume-id-attributes");
 	        my $vol_name = $vol_info->child_get_string("name");
+
+	        next if exists $Excludelist{$vol_name};
 	    
 	        my $vol_space = $vol->child_get("volume-space-attributes");
 	    
@@ -238,6 +244,10 @@ Optional: The name of the Volume to check
 =item --perf
 
 Flag for performance data output
+
+=item --exclude
+
+Optional: The name of a volume that has to be excluded from the checks (multiple exclude item for multiple volumes)
 
 =item -help
 


### PR DESCRIPTION
added the option for exclude a volume or an aggregate from the checks (useful in the cases, eg, of the default root aggregate)