### PR TITLE
Check single volume snapshots

### DIFF
--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -216,7 +216,7 @@ sub single_volume_check {
             print "OK - Snapshots OK\n";
             exit(0);
         } else {
-            print "CRITICAL - The newest snapshot is older than the time requested (".sprintf("%02d", (($now - $timestamp_best_snap)/86400))."!=".$retention_days." gg)\n";
+            print "CRITICAL - The newest snapshot is older than the time requested (".sprintf("%.2f", (($now - $timestamp_best_snap)/86400))."!=".$retention_days." gg)\n";
             exit(2);
         }
     } else {

--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -199,7 +199,7 @@ sub single_volume_check {
         if ($snapshot_info->has_children() && $snapshotnumber != 0){
             my @snapshot_list = $snapshot_info -> children_get();
             if (scalar @snapshot_list != $snapshotnumber){
-                print "WARNING - Il numero di snapshot non corrisponde a quanto richiesto (=".$snapshotnumber.")\n";
+                print "WARNING - The snapshot number is different from the requested (=".$snapshotnumber.")\n";
                 exit(1);
             }
             foreach my $snap(@snapshot_list){
@@ -219,21 +219,21 @@ sub single_volume_check {
                 }
             }
             if ($found == 1){
-                print "OK - Snapshot a posto\n";
+                print "OK - Snapshots OK\n";
                 exit(0);
             } else {
-                print "CRITICAL - La snapshot piu' recente e' piu' vecchia del tempo di retention indicato (=".$retention_days." gg)\n";
+                print "CRITICAL - The newest snapshot is older than the time requested (=".$retention_days." gg)\n";
                 exit(2);
             }
         } else {
             if ((scalar $snapshot_info->has_children() != 0) && $snapshotnumber == 0){
-                print "CRITICAL - Sono presenti delle snapshot non previste\n";
+                print "CRITICAL - There are snapshots for a volume that shouldn't have any\n";
                 exit(2);
             }elsif ((scalar $snapshot_info->has_children() == 0) && $snapshotnumber != 0){
-                print "WARNING - Il numero di snapshot non corrisponde a quanto richiesto (=".$snapshotnumber.")\n";
+                print "WARNING - The number of snapshots is different from the expected (=".$snapshotnumber.")\n";
                 exit(1);
             }else{
-                print "OK - Nessuna snapshot per il volume indicato\n";
+                print "OK - No snapshot for the requested volume\n";
                 exit(0);
             }
         }

--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -199,25 +199,24 @@ sub single_volume_check {
             print "WARNING - The snapshot number is different from the requested (".$current_snap_num."!=".$snapshotnumber.")\n";
             exit(1);
         }
-        my $iter=1;
         foreach my $snap(@snapshot_list){
             my $snap_create_time = $snap->child_get_int("access-time");
-            my $temp = $now - $snap_create_time;
             if($now - $snap_create_time <= $snaptime_second){
                 if($found == 0){
                     $found = 1;
-                    $timestamp_best_snap = $snap_create_time;
-                }elsif ($timestamp_best_snap - $snap_create_time > 0){
-                    $timestamp_best_snap = $snap_create_time;
-                }
+                    last;
+                } 
+            } elsif ($timestamp_best_snap - $snap_create_time < 0){
+                $timestamp_best_snap = $snap_create_time;
+            } elsif ($timestamp_best_snap == -1){
+                $timestamp_best_snap = $snap_create_time;
             }
-            $iter++;
         }
         if ($found == 1){
             print "OK - Snapshots OK\n";
             exit(0);
         } else {
-            print "CRITICAL - The newest snapshot is older than the time requested (".($timestamp_best_snap/86400)."!=".$retention_days." gg)\n";
+            print "CRITICAL - The newest snapshot is older than the time requested (".sprintf("%02d", (($now - $timestamp_best_snap)/86400))."!=".$retention_days." gg)\n";
             exit(2);
         }
     } else {

--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -170,7 +170,7 @@ sub single_volume_check {
         print ("ERROR: Failed script: ".$out->results_reason()."\n");
         exit(2);
     }
-    my $out = $connection->invoke(  
+    $out = $s->invoke(  
         "volume-list-info", 
         "volume", 
         $volumename
@@ -186,7 +186,7 @@ sub single_volume_check {
 
 
     foreach my $vol (@volume_list) {
-        $out = $connection -> invoke(
+        $out = $s -> invoke(
             "snapshot-list-info", 
             "target-name", $vol->child_get_string("name"),
             "target-type", "volume"

--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -19,11 +19,14 @@ use Getopt::Long;
 use Data::Dumper;
 
 GetOptions(
-    'hostname=s' => \my $Hostname,
-    'username=s' => \my $Username,
-    'password=s' => \my $Password,
-    'age=i'      => \my $AgeOpt,
-    'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+    'hostname=s'        => \my $Hostname,
+    'username=s'        => \my $Username,
+    'password=s'        => \my $Password,
+    'age=i'             => \my $AgeOpt,
+    'numbersnapshot=i'  => \my $SnapshotNumber,
+    'retentiondays=i'   => \my $retention_days,
+    'volume=s'          => \my $volumename,
+    'help|?'            => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
 
 sub Error {
@@ -182,6 +185,18 @@ The Login Password of the NetApp to monitor
 =item --age AGE-SECONDS
 
 Snapshot age in Seconds. Default 90 days
+
+=item --volume VOLUME
+
+Name of the single snapshot that has to be checked (useful for check that a snapshot retention works)
+
+=item --numbersnapshot NUMBER-ITEMS
+
+The number of snapshots that should be present in VOLUME volume (useful for check that a snapshot retention works)
+
+=item --retentiondays AGE-DAYS
+
+Snapshot age in days of the oldest snapshot in VOLUME volume (useful for check that a snapshot retention works)
 
 =item -help
 

--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -187,11 +187,13 @@ sub single_volume_check {
         exit 1;
     }
 
-    my $current_snap_num = $xo->child_get_int("num-records");
-    my $attr_list = $xo->child_get("attributes-list");
-    @snapshot_list = $attr_list->children_get();
+    my $current_snap_num = 0; 
+    $current_snap_num = $xo->child_get_int("num-records");
 
-    if ($snapshotnumber != 0){
+    if ($snapshotnumber != 0 && $current_snap_num != 0){
+        
+        my $attr_list = $xo->child_get("attributes-list");
+        @snapshot_list = $attr_list->children_get();
 
         if ($current_snap_num != $snapshotnumber){
             print "WARNING - The snapshot number is different from the requested (".$current_snap_num."!=".$snapshotnumber.")\n";
@@ -201,9 +203,6 @@ sub single_volume_check {
         foreach my $snap(@snapshot_list){
             my $snap_create_time = $snap->child_get_int("access-time");
             my $temp = $now - $snap_create_time;
-            print $iter."\n";
-            print $snaptime_second."\n";
-            print $now - $snap_create_time."\n";
             if($now - $snap_create_time <= $snaptime_second){
                 if($found == 0){
                     $found = 1;
@@ -213,7 +212,6 @@ sub single_volume_check {
                 }
             }
             $iter++;
-            print "\n\n";
         }
         if ($found == 1){
             print "OK - Snapshots OK\n";
@@ -223,11 +221,11 @@ sub single_volume_check {
             exit(2);
         }
     } else {
-        if ((scalar @snapshot_list != 0) && $snapshotnumber == 0){
+        if ($current_snap_num != 0 && $snapshotnumber == 0){
             print "CRITICAL - There are snapshots for a volume that shouldn't have any\n";
             exit(2);
-        }elsif ((scalar @snapshot_list == 0) && $snapshotnumber != 0){
-            print "WARNING - The number of snapshots is different from the expected (=".$snapshotnumber.")\n";
+        }elsif ($current_snap_num == 0 && $snapshotnumber != 0){
+            print "WARNING - The number of snapshots is different from the expected (".$current_snap_num."!=".$snapshotnumber.")\n";
             exit(1);
         }else{
             print "OK - No snapshot for the requested volume\n";


### PR DESCRIPTION
I have modified the check_cdot_snapshots.pl so that I can check:
- Number of snapshots (param. *snapshotnumber*)
- Delay of the newest snapshot (param. *retentiondays*)

Of a single snapshot declared with the *volume* parameter.
This has been necessary because I've got some volumes with no Netapp Snapshot Policy and the snapshots are made by others (eg. VMWare)