### PR TITLE
Enhancements to volume and aggr checks; more perfdata; cmdline changes

### DIFF
--- a/Templates/check_cdot_volume.php
+++ b/Templates/check_cdot_volume.php
@@ -1,0 +1,50 @@
+<?php
+#
+# check_cdot_volume.php - based on check_netappfileri_vol.php from 
+# https://github.com/wAmpIre/check_netappfiler
+#
+# RRDtool Options
+$opt[1] = "--vertical-label Bytes -l 0 -r --title \"Volume  $hostname / $servicedesc\" --height=200 -b 1024 ";
+#
+#
+# Graphen Definitions
+$def[1]  = "DEF:dataused=$rrdfile:$DS[1]:AVERAGE "; 
+$def[1] .= "DEF:inodeused=$rrdfile:$DS[2]:AVERAGE ";
+$def[1] .= "DEF:snapused=$rrdfile:$DS[3]:AVERAGE "; 
+$def[1] .= "DEF:datatotal=$rrdfile:$DS[4]:AVERAGE "; 
+$def[1] .= "DEF:snapsize=$rrdfile:$DS[5]:AVERAGE "; 
+
+// $def[1] .= "CDEF:snapsnap=snap,snapsize,GT,snapsize,snap,IF ";
+$def[1] .= "CDEF:snapfree=snapused,snapsize,GT,0,snapsize,snapused,-,IF ";
+$def[1] .= "CDEF:snapover=snapused,snapsize,GT,snapused,snapsize,-,0,IF ";
+$def[1] .= "CDEF:datafree=datatotal,dataused,- ";
+
+$def[1] .= "CDEF:warn=dataused,0,*,$WARN[1],+ ";
+$def[1] .= "CDEF:crit=dataused,0,*,$CRIT[1],+ ";
+
+$def[1] .= "AREA:dataused#aaaaaa:\"Data\: Used space\" "; 
+$def[1] .= "GPRINT:dataused:LAST:\"%6.2lf%S\\n\" ";
+$def[1] .= "AREA:datafree#00ff00:\"Data\: Free space\":STACK ";
+$def[1] .= "GPRINT:datafree:LAST:\"%6.2lf%S\\n\" ";
+$def[1] .= "AREA:snapover#aa0000:\"Snap\: Over resv.\":STACK ";
+$def[1] .= "GPRINT:snapover:LAST:\"%6.2lf%S\\n\" ";
+$def[1] .= "AREA:snapfree#00ffff:\"Snap\: Free space\":STACK ";
+$def[1] .= "GPRINT:snapfree:LAST:\"%6.2lf%S\\n\" ";
+$def[1] .= "AREA:snapused#0000cc:\"Snap\: Used space\":STACK ";
+$def[1] .= "GPRINT:snapused:LAST:\"%6.2lf%S\\n\" ";
+
+$def[1] .= "LINE1:datatotal#000000 "; 
+
+$def[1] .= "LINE2:datafree#ffffff:\"Available space \": ";
+$def[1] .= "GPRINT:datafree:LAST:\"%6.2lf%S\\n\" ";
+
+if ($WARN[1] != "") {
+	$def[1] .= "LINE1:warn#ffff00:\"Warning at      \" ";
+	$def[1] .= "GPRINT:warn:LAST:\"%6.2lf%S\\n\" ";
+}
+if ($CRIT[1] != "") {
+	$def[1] .= "LINE1:crit#ff0000:\"Critical at     \" ";
+	$def[1] .= "GPRINT:crit:LAST:\"%6.2lf%S\\n\" ";
+}
+
+?>

--- a/check_cdot_aggr.pl
+++ b/check_cdot_aggr.pl
@@ -16,19 +16,19 @@ use warnings;
 use lib "/usr/lib/netapp-manageability-sdk/lib/perl/NetApp";
 use NaServer;
 use NaElement;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 use Data::Dumper;
 
 GetOptions(
-    'hostname=s' => \my $Hostname,
-    'username=s' => \my $Username,
-    'password=s' => \my $Password,
-    'warning=i'  => \my $Warning,
-    'critical=i' => \my $Critical,
-    'aggr=s'     => \my $Aggr,
-    'perf'       => \my $perf,
+    'H|hostname=s' => \my $Hostname,
+    'u|username=s' => \my $Username,
+    'p|password=s' => \my $Password,
+    'w|warning=i'  => \my $Warning,
+    'c|critical=i' => \my $Critical,
+    'A|aggr=s'     => \my $Aggr,
+    'P|perf'       => \my $perf,
     'exclude=s'  => \my @excludelistarray,
-    'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+    'h|help'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
 
 my %Excludelist;
@@ -100,15 +100,18 @@ while(defined($next)){
 
     foreach my $aggr (@result){
 
-        
 
         my $aggr_name = $aggr->child_get_string("aggregate-name");
 
+	# Attempt to exclude root aggregates for nodes?
         unless($aggr_name =~ m/^aggr0_/){
 
             next if exists $Excludelist{$aggr_name};
 
             my $space = $aggr->child_get("aggr-space-attributes");
+	    my $bytesused = $space->child_get_int("size-used");
+	    my $bytesavail = $space->child_get_int("size-available");
+	    my $bytestotal = $space->child_get_int("size-total");
             my $percent = $space->child_get_int("percent-used-capacity");
 
             $critical++ if $percent >= $Critical;
@@ -122,7 +125,7 @@ while(defined($next)){
             }   
 
             if ($perf) {
-                $perfmsg .= " $aggr_name=$percent%;$Warning;$Critical";
+                $perfmsg .= " $aggr_name=$percent%;$Warning;$Critical ".$aggr_name."_Used=$bytesused";
             }
             else {
                 $perfmsg .= "$aggr_name=$percent%;$Warning;$Critical";
@@ -160,9 +163,9 @@ check_cdot_aggr - Check Aggregate real Space Usage
 
 =head1 SYNOPSIS
 
-check_cdot_aggr.pl --hostname HOSTNAME --username USERNAME \
-           --password PASSWORD --warning PERCENT_WARNING \
-           --critical PERCENT_CRITICAL (--perf) (--aggr AGGR)
+check_cdot_aggr.pl -H HOSTNAME -u USERNAME \
+           -p PASSWORD -w PERCENT_WARNING \
+           -c PERCENT_CRITICAL [--perf|-P] [--aggr AGGR]
 
 =head1 DESCRIPTION
 
@@ -173,31 +176,31 @@ if warning or critical Thresholds are reached
 
 =over 4
 
-=item --hostname FQDN
+=item -H | --hostname FQDN
 
 The Hostname of the NetApp to monitor
 
-=item --username USERNAME
+=item -u | --username USERNAME
 
 The Login Username of the NetApp to monitor
 
-=item --password PASSWORD
+=item -p | --password PASSWORD
 
 The Login Password of the NetApp to monitor
 
-=item --warning PERCENT_WARNING
+=item -w | --warning PERCENT_WARNING
 
 The Warning threshold
 
-=item --critical PERCENT_CRITICAL
+=item -c | --critical PERCENT_CRITICAL
 
 The Critical threshold
 
-=item --perf
+=item -P | --perf
 
 Flag for performance data output
 
-=item --aggr
+=item -A | --aggr
 
 Check only specific aggregate
 

--- a/check_cdot_disk.pl
+++ b/check_cdot_disk.pl
@@ -122,9 +122,10 @@ while(defined($next)){
 	$next = $output->child_get_string("next-tag");
 }
 
-my $perfdatastr = sprintf(" | Aggregate=%dDisks Spare=%dDisks Rebuilding=%dDisks Failed=%dDisks",
+my $perfdatastr='';
+$perfdatastr = sprintf(" | Aggregate=%dDisks Spare=%dDisks Rebuilding=%dDisks Failed=%dDisks",
     $inventory{'Aggregate'}, $inventory{'Spare'}, $inventory{'Rebuilding'}, $inventory{'Failed'}
-);
+) if ($perf);
 
 if ( scalar @disk_list >= $critical ) {
     print "CRITICAL: " . @disk_list . ' failed disk(s): ' . join( ', ', @disk_list ) . $perfdatastr ."\n";

--- a/check_cdot_disk.pl
+++ b/check_cdot_disk.pl
@@ -76,7 +76,6 @@ while(defined($next)){
 	
 	    $disk_count++;
 	
-	    #print Dumper $container
 	    if ( $container eq 'shared' ) {
 	        # Dig deeper
 		my $shared_info = $raid_type->child_get("disk-shared-info");

--- a/check_cdot_global.pl
+++ b/check_cdot_global.pl
@@ -220,7 +220,7 @@ check_cdot_global.pl - Checks health status ( powersupplys, fans, ... )
 =head1 SYNOPSIS
 
 check_cdot_global -H HOSTNAME -u USERNAME \
-           -p PASSWORD --plugin fan
+           -p PASSWORD --plugin PLUGIN
 
 =head1 DESCRIPTION
 

--- a/check_cdot_global.pl
+++ b/check_cdot_global.pl
@@ -16,14 +16,14 @@ use warnings;
 use lib "/usr/lib/netapp-manageability-sdk/lib/perl/NetApp";
 use NaServer;
 use NaElement;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 
 GetOptions(
-    'hostname=s' => \my $Hostname,
-    'username=s' => \my $Username,
-    'password=s' => \my $Password,
+    'H|hostname=s' => \my $Hostname,
+    'u|username=s' => \my $Username,
+    'p|password=s' => \my $Password,
     'plugin=s'   => \my $Plugin,
-    'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+    'h|help'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
 
 sub Error {
@@ -170,9 +170,8 @@ given ($Plugin) {
             print "OK: No failed power supplys\n";
             exit 0;
         }
-	}
+    }
     when("fan"){
-
         if ($sum_failed_fan) {
             print "CRITICAL: $sum_failed_fan failed fan(s): $failed_node\n";
             exit 2;
@@ -180,7 +179,7 @@ given ($Plugin) {
             print "OK: No failed fans\n";
             exit 0;
         }
-	}
+    }
     when("nvram"){
         if ($sum_failed_nvram) {
             print "CRITICAL: $sum_failed_nvram failed nvram(s): $failed_node\n";
@@ -189,7 +188,7 @@ given ($Plugin) {
             print "OK: No failed nvram\n";
             exit 0;
         }
-	}
+    }
     when("temp"){
         if ($sum_failed_temp) {
             print "CRITICAL: Temperature Overheating: $failed_node\n";
@@ -198,16 +197,16 @@ given ($Plugin) {
             print "OK: Temperature OK\n";
             exit 0;
         } 
-	}
-	when("health"){
-		if ($sum_failed_health){
+    }
+    when("health"){
+	    if ($sum_failed_health){
             print "CRITICAL: Health Status Critical: $failed_node\n";
             exit 2;
         } else {
             print "OK: Health Status OK\n";
             exit 0;
         }
-	}
+    }
 }
 
 __END__
@@ -220,8 +219,8 @@ check_cdot_global.pl - Checks health status ( powersupplys, fans, ... )
 
 =head1 SYNOPSIS
 
-check_cdot_global --hostname HOSTNAME --username USERNAME \
-           --password PASSWORD --plugin fan
+check_cdot_global -H HOSTNAME -u USERNAME \
+           -p PASSWORD --plugin fan
 
 =head1 DESCRIPTION
 
@@ -236,15 +235,15 @@ Checks Health Status of:
 
 =over 4
 
-=item --hostname FQDN
+=item -H | --hostname FQDN
 
 The Hostname of the NetApp to check
 
-=item --username USERNAME
+=item -u | --username USERNAME
 
 The Login Username of the NetApp to check
 
-=item --password PASSWORD
+=item -p | --password PASSWORD
 
 The Login Password of the NetApp to check
 

--- a/check_cdot_quota.pl
+++ b/check_cdot_quota.pl
@@ -1,0 +1,251 @@
+#!/usr/bin/perl
+
+# nagios: -epn
+# --
+# check_cdot_quota - Check quota usage
+# Copyright (C) 2016 Joshua Malone (jmalone@nrao.edu)
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (GPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/gpl.txt.
+# --
+
+use strict;
+use warnings;
+
+use lib "/usr/lib/netapp-manageability-sdk/lib/perl/NetApp";
+use NaServer;
+use NaElement;
+use Getopt::Long qw(:config no_ignore_case);
+
+GetOptions(
+    'H|hostname=s' => \my $Hostname,
+    'u|username=s' => \my $Username,
+    'p|password=s' => \my $Password,
+    'w|warning=i'  => \my $SizeWarning,
+    'c|critical=i' => \my $SizeCritical,
+    'P|perf'     => \my $perf,
+    "V|volume=s" => \my $Volume,
+    't|target=s'   => \my $Quota,
+    'v|verbose' => \my $verbose,
+    'h|help'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+) or Error("$0: Error in command line arguments\n");
+
+sub Error {
+    print "UNKNOWN: $0: " . $_[0] . "\n";
+    exit 3;
+}
+Error('Option --hostname needed!') unless $Hostname;
+Error('Option --username needed!') unless $Username;
+Error('Option --password needed!') unless $Password;
+Error('Option -w needed!')  unless $SizeWarning;
+Error('Option -c needed!') unless $SizeCritical;
+Error('Critical space threshold must be greater than Warning!') if ($SizeWarning > $SizeCritical);
+if ($Quota && !$Volume) {
+    Error('Option -t requires a Volume name (-V)!');
+}
+
+# Set some conservative default thresholds for the more
+# esoteric metrics
+
+my ($crit_msg, $warn_msg, $ok_msg);
+# Store all perf data points for output at end
+my %perfdata=();
+
+my $s = NaServer->new( $Hostname, 1, 3 );
+$s->set_transport_type("HTTPS");
+$s->set_style("LOGIN");
+$s->set_admin_user( $Username, $Password );
+
+my $iterator = NaElement->new("quota-report-iter");
+my $tag_elem = NaElement->new("tag");
+$iterator->child_add($tag_elem);
+
+my $quota_query = NaElement->new("query");
+my $quota_info = NaElement->new("quota");
+
+if ($Volume) {
+    print("Querying only volume $Volume\n") if ($verbose);
+    $iterator->child_add($quota_query);
+    $quota_query->child_add($quota_info);
+    $quota_info->child_add_string('volume', $Volume);
+}
+if ($Quota) {
+    $quota_info->child_add_string('quota-target', $Quota);
+}
+
+my $next = "";
+my (@crit_msg, @warn_msg, @ok_msg);
+
+while(defined($next)){
+    unless($next eq ""){
+        $tag_elem->set_content($next);    
+    }
+    $iterator->child_add_string("max-records", 100);
+    my $output = $s->invoke_elem($iterator);
+    last if ($output->child_get_string("num-records") == 0 );
+
+    if ($output->results_errno != 0) {
+	my $r = $output->results_reason();
+	print "UNKNOWN: $r\n";
+	exit 3;
+    }
+
+    foreach my $getQuota ( $output->child_get("attributes-list")->children_get() ) {
+	my $diskLimit = $getQuota->child_get_string('disk-limit');
+	next if ($diskLimit eq "-" or $diskLimit == 0 );
+	my $diskUsed = $getQuota->child_get_string('disk-used');
+	my $fileLimit = $getQuota->child_get_string('file-limit');
+	my $filesUsed = $getQuota->child_get_string('files-used');
+	my $volume = $getQuota->child_get_string('volume');
+	my $type = $getQuota->child_get_string('quota-type');
+	my $target;
+	if ($type eq "user") {
+	    my $qUsers = $getQuota->child_get('quota-users');
+	    next unless ($qUsers);
+	    my $qUser= $qUsers->child_get('quota-user');
+	    next unless ($qUser);
+	    my $quotaUser = $qUser->child_get_string('quota-user-name');
+	    printf("Found quota for %s on %s\n", $quotaUser, $volume) if ($verbose);
+	    $target = sprintf("%s/%s", $volume, $quotaUser);
+	} else {
+	    $target = $getQuota->child_get_string('quota-target');
+	}
+	printf ("Quota %s: %s %s %s %s\n", $target, $diskLimit, $diskUsed, $fileLimit, $filesUsed) if ($verbose);
+	my $diskPercent=($diskUsed/$diskLimit*100);
+
+	my $msg = sprintf ("Quota %s is %d%% full (used %d of %d bytes)",
+	    $target, $diskPercent, $diskUsed, $diskLimit);
+	if ($diskPercent >= $SizeCritical) {
+	    push (@crit_msg, $msg);
+	} elsif ($diskPercent >= $SizeWarning) {
+	    push (@warn_msg, $msg);
+	} else {
+	    push (@ok_msg, $msg);
+	}
+	if ($fileLimit ne "-" ) {
+	    # Check files limit as well as space
+	}
+
+	$perfdata{$target}{'byte_used'}=$diskUsed;
+	$perfdata{$target}{'byte_total'}=$diskLimit;
+	$perfdata{$target}{'files_used'}=$filesUsed;
+	$perfdata{$target}{'file_limit'}=$fileLimit;
+    }
+    $next = $output->child_get_string("next-tag");
+}
+
+# Build perf data string for output
+my $perfdatastr="";
+foreach my $vol ( keys(%perfdata) ) {
+    # DS[1] - Data space used
+    $perfdatastr.=sprintf(" %s_space_used=%dBytes;%d;%d;%d;%d", $vol, $perfdata{$vol}{'byte_used'},
+	$SizeWarning*$perfdata{$vol}{'byte_total'}/100, $SizeCritical*$perfdata{$vol}{'byte_total'}/100,
+	0, $perfdata{$vol}{'byte_total'} );
+}
+
+if(scalar(@crit_msg) ){
+    print "CRITICAL: ";
+    print join ("; ", @crit_msg, @warn_msg, @ok_msg);
+    print "|$perfdatastr\n";
+    exit 2;
+} elsif(scalar(@warn_msg) ){
+    print "WARNING: ";
+    print join ("; ", @crit_msg, @warn_msg, @ok_msg);
+    print "|$perfdatastr\n";
+    exit 1;
+} elsif(scalar(@ok_msg) ){
+    print "OK: ";
+    print join ("; ", @crit_msg, @warn_msg, @ok_msg);
+    print "|$perfdatastr\n";
+    exit 0;
+} else {
+    print "WARNING: no online volume found\n";
+    exit 1;
+}
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+check_cdot_volume - Check Volume Usage
+
+=head1 SYNOPSIS
+
+check_cdot_quota.pl -H HOSTNAME -u USERNAME -p PASSWORD \
+           -w PERCENT_WARNING -c PERCENT_CRITICAL \
+	   --files-warning PERCENT_WARNING \
+           --files-critical PERCENT_CRITICAL [-V VOLUME] [-P]
+
+=head1 DESCRIPTION
+
+Checks the space and files usage of a quota / qtree and alerts
+if warning or critical thresholds are reached
+
+=head1 OPTIONS
+
+=over 4
+
+=item -H | --hostname FQDN
+
+The Hostname of the NetApp to monitor
+
+=item -u | --username USERNAME
+
+The Login Username of the NetApp to monitor
+
+=item -p | --password PASSWORD
+
+The Login Password of the NetApp to monitor
+
+=item -w PERCENT_WARNING
+
+The Warning threshold for data space usage.
+
+=item -c PERCENT_CRITICAL
+
+The Critical threshold for data space usage.
+
+=item --files-warning PERCENT_WARNING
+
+The Warning threshold for files used. Defaults to 65% if not given.
+
+=item --inode-critical PERCENT_CRITICAL
+
+The Critical threshold for files used. Defaults to 85% if not given.
+
+=item -V | --volume VOLUME
+
+Optional: The name of the Volume on which quotas should be checked.
+
+=item -t | --target TARGET
+
+Optional: The target of a specific quota / qtree that should be checked.
+To use this option, you **MUST** specify a  volume.  
+
+=item -P --perf
+
+Ouput performance data.
+
+=item -help
+
+=item -h
+
+to see this Documentation
+
+=back
+
+=head1 EXIT CODE
+
+3 on Unknown Error
+2 if Critical Threshold has been reached
+1 if Warning Threshold has been reached or any problem occured
+0 if everything is ok
+
+=head1 AUTHORS
+
+ Joshua Malone <jmalone at nrao.edu>
+ Alexander Krogloth <git at krogloth.de>
+ Stefan Grosser <sgr at firstframe.net>

--- a/check_cdot_rebuild.pl
+++ b/check_cdot_rebuild.pl
@@ -16,13 +16,13 @@ use warnings;
 use lib "/usr/lib/netapp-manageability-sdk/lib/perl/NetApp";
 use NaServer;
 use NaElement;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 
 GetOptions(
-    'hostname=s' => \my $Hostname,
-    'username=s' => \my $Username,
-    'password=s' => \my $Password,
-    'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+    'H|hostname=s' => \my $Hostname,
+    'u|username=s' => \my $Username,
+    'p|password=s' => \my $Password,
+    'h|help'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
 
 sub Error {
@@ -110,8 +110,7 @@ check_cdot_rebuild - Check Aggregate State
 
 =head1 SYNOPSIS
 
-check_cdot_rebuild.pl --hostname HOSTNAME --username USERNAME \
-           --password PASSWORD 
+check_cdot_rebuild.pl -H HOSTNAME -u USERNAME -p PASSWORD 
 
 =head1 DESCRIPTION
 
@@ -122,19 +121,19 @@ critical if any raidgroup is reconstructing
 
 =over 4
 
-=item --hostname FQDN
+=item -H | --hostname FQDN
 
 The Hostname of the NetApp to monitor
 
-=item --username USERNAME
+=item -u | --username USERNAME
 
 The Login Username of the NetApp to monitor
 
-=item --password PASSWORD
+=item -p | --password PASSWORD
 
 The Login Password of the NetApp to monitor
 
-=item -help
+=item -h | -help
 
 =item -?
 

--- a/check_cdot_volume.pl
+++ b/check_cdot_volume.pl
@@ -44,8 +44,8 @@ Error('Option --username needed!') unless $Username;
 Error('Option --password needed!') unless $Password;
 Error('Option --size-warning needed!')  unless $SizeWarning;
 Error('Option --size-critical needed!') unless $SizeCritical;
-Error('Option --inode-warning needed!')  unless $InodeWarning;
-Error('Option --inode-critical needed!') unless $InodeCritical;
+$InodeWarning = 65 unless $InodeWarning;
+$InodeCritical = 85 unless $InodeCritical;
 
 my ($crit_msg, $warn_msg, $ok_msg);
 

--- a/check_cdot_volume.pl
+++ b/check_cdot_volume.pl
@@ -231,11 +231,11 @@ The Critical threshold
 
 =item --inode-warning PERCENT_WARNING
 
-The Warning threshold
+The Warning threshold for inodes (files). Defaults to 65% if not given.
 
 =item --inode-critical PERCENT_CRITICAL
 
-The Critical threshold
+The Critical threshold for inodes (files). Defaults to 85% if not given.
 
 =item -V | --volume VOLUME
 

--- a/check_cdot_volume.pl
+++ b/check_cdot_volume.pl
@@ -16,18 +16,18 @@ use warnings;
 use lib "/usr/lib/netapp-manageability-sdk/lib/perl/NetApp";
 use NaServer;
 use NaElement;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 
 GetOptions(
-    'hostname=s' => \my $Hostname,
-    'username=s' => \my $Username,
-    'password=s' => \my $Password,
-    'size-warning=i'  => \my $SizeWarning,
-    'size-critical=i' => \my $SizeCritical,
+    'H|hostname=s' => \my $Hostname,
+    'u|username=s' => \my $Username,
+    'p|password=s' => \my $Password,
+    'w|size-warning=i'  => \my $SizeWarning,
+    'c|size-critical=i' => \my $SizeCritical,
     'inode-warning=i'  => \my $InodeWarning,
     'inode-critical=i' => \my $InodeCritical,
-    'perf'     => \my $perf,
-    'volume=s'   => \my $Volume,
+    'P|perf'     => \my $perf,
+    'V|volume=s'   => \my $Volume,
     'exclude=s'	 =>	\my @excludelistarray,
     'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
@@ -195,10 +195,10 @@ check_cdot_volume - Check Volume Usage
 
 =head1 SYNOPSIS
 
-check_cdot_aggr.pl --hostname HOSTNAME --username USERNAME \
-           --password PASSWORD --size-warning PERCENT_WARNING \
-           --size-critical PERCENT_CRITICAL --inode-warning PERCENT_WARNING \
-           --inode-critical PERCENT_CRITICAL (--volume VOLUME) (--perf)
+check_cdot_aggr.pl -H HOSTNAME -u USERNAME -p PASSWORD \
+           -w PERCENT_WARNING -c PERCENT_CRITICAL \
+	   --inode-warning PERCENT_WARNING \
+           --inode-critical PERCENT_CRITICAL [-V VOLUME] [-P]
 
 =head1 DESCRIPTION
 
@@ -209,15 +209,15 @@ if warning or critical Thresholds are reached
 
 =over 4
 
-=item --hostname FQDN
+=item -H | --hostname FQDN
 
 The Hostname of the NetApp to monitor
 
-=item --username USERNAME
+=item -u | --username USERNAME
 
 The Login Username of the NetApp to monitor
 
-=item --password PASSWORD
+=item -p | --password PASSWORD
 
 The Login Password of the NetApp to monitor
 
@@ -237,11 +237,11 @@ The Warning threshold
 
 The Critical threshold
 
-=item --volume VOLUME
+=item -V | --volume VOLUME
 
 Optional: The name of the Volume to check
 
-=item --perf
+=item -P --perf
 
 Flag for performance data output
 

--- a/check_cdot_volume.pl
+++ b/check_cdot_volume.pl
@@ -182,20 +182,20 @@ foreach my $vol ( keys(%perfdata) ) {
 if($crit_msg){
     print "CRITICAL: $crit_msg\n";
     if($warn_msg){
-        print "WARNING: $warn_msg\n";
+        print "WARNING: $warn_msg |$perfdatastr\n";
     }
     if($ok_msg){
-        print "OK: $ok_msg\n";
+        print "OK: $ok_msg |$perfdatastr\n";
     }
     exit 2;
 } elsif($warn_msg){
-    print "WARNING: $warn_msg\n";
+    print "WARNING: $warn_msg |$perfdatastr\n";
     if($ok_msg){
-        print "OK: $ok_msg\n";
+        print "OK: $ok_msg |$perfdatastr\n";
     }
     exit 1;
 } elsif($ok_msg){
-    print "OK: $ok_msg | $perfdatastr\n";
+    print "OK: $ok_msg |$perfdatastr\n";
     exit 0;
 } else {
     print "WARNING: no online volume found\n";


### PR DESCRIPTION
This merge request adds lots of additional performance data to volume and aggregate checks. Volume checks can now generate a stacked graph showing space breakdown in the volume (data, free, snap).

Several plugins have been changed to accept the Nagios-standard "-H" option to specify the hostname. Other minor changes made to options handling -- see help output. (the '-?' flag has been removed in favor of '-h')