### PR TITLE
check_cdot_diff_snapmirror.pl: Added --exclude and --regexp options, added help part

### DIFF
--- a/check_cdot_diff_snapmirror.pl
+++ b/check_cdot_diff_snapmirror.pl
@@ -23,9 +23,15 @@ GetOptions(
     'hostname=s' => \my $Hostname,
     'username=s' => \my $Username,
     'password=s' => \my $Password,
+    'exclude=s'  => \my @excludelistarray,
+    'regexp'     => \my $regexp,	
     'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
 
+my %Excludelist;
+@Excludelist{@excludelistarray}=();
+my $excludeliststr = join "|", @excludelistarray;
+		
 sub Error {
     print "$0: " . $_[0] . "\n";
     exit 2;
@@ -46,6 +52,8 @@ $snap_iterator->child_add($tag_elem);
 my $next = "";
 my @snapmirror_sources;
 my @missing_snapmirror;
+my @auto_excluded_volumes;
+my @manually_excluded_volumes;
 
 while(defined($next)){
 	unless($next eq ""){
@@ -61,7 +69,14 @@ while(defined($next)){
 		exit 3;
 	}
 
-	my @snapmirrors = $snap_output->child_get("attributes-list")->children_get();
+        my $num_records = $snap_output->child_get_string("num-records");
+
+        if($num_records eq 0){
+                print "OK - Nothing to check\n";
+                exit 0;
+        }
+	
+        my @snapmirrors = $snap_output->child_get("attributes-list")->children_get();
 
 	foreach my $snap (@snapmirrors){
         my $source = $snap->child_get_string("source-location");
@@ -112,28 +127,116 @@ while(defined($next)){
         my $vol_name = $id->child_get_string("name");
         my $type = $id->child_get_string("type");
 
-        unless(($vol_name =~ m/vol0/) || ( $type eq "dp") || ($vol_name =~ m/_root$/)){
+        my $vserver = $id->child_get_string("owning-vserver-name");
+        my $location = "$vserver:$vol_name";
 
-            my $vserver = $id->child_get_string("owning-vserver-name");
-            my $location = "$vserver:$vol_name";
-    
-            my $result = grep (/$location/,@snapmirror_sources);
+        # notes:
+        #  ^MDV_CRS : CDOT Meta Data
+        if (($vol_name =~ m/^MDV_CRS|vol0|_root$/) || ($type eq "dp")){
+            push(@auto_excluded_volumes,$location."\n");
+            next;
+        }
 
-            unless($result){
-                push(@missing_snapmirror,$location);
+        if (exists $Excludelist{$vol_name}) {
+            push(@manually_excluded_volumes,$location."\n");
+            next;
+        }
+		
+        if ($regexp and $excludeliststr) {
+            if ($vol_name =~ m/$excludeliststr/) {
+                push(@manually_excluded_volumes,$location."\n");
+                next;
             }
+        }
+
+        my $result = grep (/$location/,@snapmirror_sources);
+
+        unless($result){
+            push(@missing_snapmirror,$location."\n");
         }
     }
     $next = $output->child_get_string("next-tag");
 }
 
 if (@missing_snapmirror) {
-    print @missing_snapmirror . " volume(s) without snapmirror:\n";
+    print @missing_snapmirror . " volume(s) without snapmirror|\n";
+    print "Volume(s) without snapmirror:\n";
     print "@missing_snapmirror\n";
-    exit 2;
+    print "Manually excluded volume(s):\n";
+    print "@manually_excluded_volumes\n";
+    print "Auto excluded volume(s):\n";
+    print "@auto_excluded_volumes\n";
+    exit 1;
 }
 else {
-    print "All volumes are snapmirrored\n";
+    print "All volumes are snapmirrored|\n";
+    print "Manually excluded volume(s):\n";
+    print "@manually_excluded_volumes\n";
+    print "Auto excluded volume(s):\n";
+    print "@auto_excluded_volumes\n";
     exit 0;
 }
 
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+check_cdot_diff_snapmirror - Checks SnapMirror Configuration
+
+=head1 SYNOPSIS
+
+check_cdot_snapmirror.pl --hostname HOSTNAME --username USERNAME --password PASSWORD
+           [--exclude VOLUME-NAME] [--regexp] [--verbose]
+
+=head1 DESCRIPTION
+
+Checks that all the volumes have a SnapMirror configuration
+
+=head1 OPTIONS
+
+=over 4
+
+=item --hostname FQDN
+
+The Hostname of the NetApp to monitor
+
+=item --username USERNAME
+
+The Login Username of the NetApp to monitor
+
+=item --password PASSWORD
+
+The Login Password of the NetApp to monitor
+
+=item --exclude
+
+Optional: The name of a volume that has to be excluded from the checks (multiple exclude item for multiple volumes)
+
+=item --regexp
+
+Optional: Enable regexp matching for the exclusion list
+
+=item -v | --verbose
+
+Enable verbose mode
+
+=item -help
+
+=item -?
+
+to see this Documentation
+
+=back
+
+=head1 EXIT CODE
+
+3 if timeout occured
+2 if there is an error in the SnapMirror
+0 if everything is ok
+
+=head1 AUTHORS
+
+ Alexander Krogloth <git at krogloth.de>
+ Stelios Gikas <sgikas at demokrit.de>


### PR DESCRIPTION
Hello,
Added some options to the check_cdot_diff_snapmirror.pl script.
--exclude and --regexp are for volume exclusion, so the snapmirror configuration is not checked in case the vol is in the exclude list.
Added help part
BR,
Yannick