### PR TITLE
Update check_cdot_disk.pl with correct UOM in perfdata output

### DIFF
--- a/check_cdot_disk.pl
+++ b/check_cdot_disk.pl
@@ -129,7 +129,7 @@ while(defined( $next )){
 }
 
 my $perfdatastr='';
-$perfdatastr = sprintf(" | Aggregate=%dDisks Spare=%dDisks Rebuilding=%dDisks Failed=%dDisks",
+$perfdatastr = sprintf(" | Aggregate=%d Spare=%d Rebuilding=%d Failed=%d",
     $inventory{'Aggregate'}, $inventory{'Spare'}, $inventory{'Rebuilding'}, $inventory{'Failed'}
 ) if ($perf);
 


### PR DESCRIPTION
Changed the UOM in perfdata output from the unsupported "Disks" to nothing. This way monitoring systems handle the perfdata as simple interger/float values.