### PR TITLE
Feature request: check_cdot_snapshots.pl Switch for WARN/Crit on old snapshots

### DIFF
--- a/check_cdot_snapshots.pl
+++ b/check_cdot_snapshots.pl
@@ -29,6 +29,7 @@ GetOptions(
     'busy'              => \my $busy_check,
     'exclude=s'         => \my @excludelistarray,
     'regexp'            => \my $regexp,
+    'exitcritical'      => \my $exitcritical,
     'v|verbose'         => \my $verbose,
     'help|?'            => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error("$0: Error in command line arguments\n");
@@ -174,7 +175,12 @@ if (@old_snapshots) {
             print "$snap ($busy_snapshots{$snap})\n";
         }
     }
-    exit 1;
+    if($exitcritical){
+      exit 2;
+    }
+    else{
+      exit 1;
+    }
 }
 else {
     if (!%busy_snapshots){


### PR DESCRIPTION
add option "exitcritical" to get a CRITICAl state on old snapshots

```
# '/usr/lib64/nagios/plugins/check_cdot_snapshots.pl' '--hostname' 'ip' '--password' 'a' '--username' 'user'
4 snapshot(s) older than 90.0 day(s)|
* Snapshot(s) older than 90.0 day(s)
names here
# echo $?
1

# '/usr/lib64/nagios/plugins/check_cdot_snapshot_tests.pl' '--hostname' 'ip' '--password' 'a' '--username' 'user' --exitcritical
4 snapshot(s) older than 90.0 day(s)|
* Snapshot(s) older than 90.0 day(s)
names here
# echo $?
2
```
seems to work