### PR TITLE
fix multitpath count for A800 with local disks and remote disks

### DIFF
--- a/check_cdot_multipath.pl
+++ b/check_cdot_multipath.pl
@@ -142,7 +142,7 @@ while(defined( $next )){
                 $new_must_paths = $must_paths;
             }
 
-            unless($path_count eq $new_must_paths){
+            unless($path_count ge $new_must_paths){
                 push @failed_disks, $disk_name;
             }
         }


### PR DESCRIPTION
* On A800 IP-fabric metrocluster local disks have two paths and remote disks still have 8 paths with IOM Type psm3e.