### PR TITLE
Update check_cdot_clusterlinks.pl

### DIFF
--- a/check_cdot_clusterlinks.pl
+++ b/check_cdot_clusterlinks.pl
@@ -102,7 +102,6 @@ foreach my $node (@node_result) {
         }
 
         my $link_status = $cf_output->child_get_string( "interconnect-links" );
-        $link_status = (split( /[()]/, $link_status ))[1];
 
         if (grep(/down/, $link_status)) {
             $failed_ics{$node_name} = $link_status;


### PR DESCRIPTION
Hi Alex,

I just found out that running this script against a AFF-A250 with VERSION 9.10.1P4 produces the following output:
```
Use of uninitialized value $_ in pattern match (m//) at /usr/lib/nagios/plugins/check_cdot_clusterlinks.pl line 107.
Use of uninitialized value $_ in pattern match (m//) at /usr/lib/nagios/plugins/check_cdot_clusterlinks.pl line 107.
OK: all clusterlinks up
```

This is because the result of line 104 has no brackets `()` in the string.
I have simply removed the split/match for the brackets. Not sure if that works in all scenarios though.

Another "solution" could be 
```perl
if (grep(/[()]/, $link_status)){
                $link_status = (split( /[()]/, $link_status ))[1];
}
```