### PR TITLE
Add minimum paths for MetroCluster IP fabric

### DIFF
--- a/check_cdot_multipath.pl
+++ b/check_cdot_multipath.pl
@@ -67,6 +67,8 @@ if($config_state eq "configured") {
         $must_paths = 2;
     } elsif($type eq "fabric") {
         $must_paths = 8;
+    } elsif($type eq "ip_fabric") {
+        $must_paths = 8;
     } else {
         $must_paths = 4;
     }


### PR DESCRIPTION
MetroCluster configuration type when using IP fabric does not match the current cases for setting paths threshold, and the fallback 4 is not enough. Also see https://kb.netapp.com/Advice_and_Troubleshooting/Data_Protection_and_Security/MetroCluster/Is_it_expected_to_see_8_instead_of_4_paths_to_the_remote_disks_of_a_MetroCluster_IP%3F why 8 are correct.