### PR TITLE
Update check_cdot_multipath.pl

### DIFF
--- a/check_cdot_multipath.pl
+++ b/check_cdot_multipath.pl
@@ -145,10 +145,10 @@ while(defined( $next )){
 
             my $new_must_paths;
 
-            # Internal disks i.e. A700s have 8 paths, A800 (psm3e) and A/C250 (nsm8e) and A70/A90 (nsm16e) have two paths
+            # Internal disks i.e. A700s have 8 paths, A800 (psm3e) and A150 (iom12e) and A/C250 (nsm8e) and A70/A90 (nsm16e) have two paths
             if($iom_type eq "iom12f"){
                 $new_must_paths = "8";
-            } elsif ($iom_type eq "psm3e" or $iom_type eq "nsm8e" or $iom_type eq "nsm16e"){
+            } elsif ($iom_type eq "psm3e" or $iom_type eq "iom12e" or $iom_type eq "nsm8e" or $iom_type eq "nsm16e"){
                 $new_must_paths = "2";
             } else {
                 $new_must_paths = $must_paths;


### PR DESCRIPTION
Fixed multipath check for NetApp AFF-A150 which uses only 2 paths.