### PR TITLE
Replaced deprecated given/when and smartmatch statements (producing warnings) and skip vlan/vip ports

### DIFF
--- a/check_cdot_global.pl
+++ b/check_cdot_global.pl
@@ -18,9 +18,6 @@ use NaServer;
 use NaElement;
 use Getopt::Long qw(:config no_ignore_case);
 
-# ignore warning for experimental 'given'
-no if ($] >= 5.018), 'warnings' => 'experimental';
-
 GetOptions(
     'H|hostname=s' => \my $Hostname,
     'u|username=s' => \my $Username,
@@ -59,7 +56,7 @@ $iterator->child_add( $tag_elem );
 
 my $next = "";
 
-my ($sum_failed_power, $sum_failed_nvram, $sum_failed_temp, $sum_failed_fan, $sum_failed_health) = 0;
+my ($sum_failed_power, $sum_failed_nvram, $sum_failed_temp, $sum_failed_fan, $sum_failed_health) = (0,0,0,0,0);
 
 while(defined( $next )){
     unless ($next eq "") {
@@ -78,85 +75,79 @@ while(defined( $next )){
     my $heads = $output->child_get( "attributes-list" );
     my @result = $heads->children_get();
 
-    given ($Plugin) {
-        when("power") {
-            foreach my $head (@result) {
-                my $failed_power_count = $head->child_get_string( "env-failed-power-supply-count" );
-                my $node_name = $head->child_get_string( "node" );
-                if ($failed_power_count) {
-                    $sum_failed_power++;
+    if ($Plugin eq "power") {
+        foreach my $head (@result) {
+            my $failed_power_count = $head->child_get_string( "env-failed-power-supply-count" );
+            my $node_name = $head->child_get_string( "node" );
+            if ($failed_power_count) {
+                $sum_failed_power++;
 
-                    if ($failed_node) {
-                        $failed_node .= ", $node_name";
-                    } else {
-                        $failed_node .= $node_name;
-                    }
+                if ($failed_node) {
+                    $failed_node .= ", $node_name";
+                } else {
+                    $failed_node .= $node_name;
                 }
             }
         }
+    }
+    elsif ($Plugin eq "fan") {
+        foreach my $head (@result) {
+            my $failed_fan_count = $head->child_get_string( "env-failed-fan-count" );
+            my $node_name = $head->child_get_string( "node" );
 
-        when("fan") {
-            foreach my $head (@result) {
-                my $failed_fan_count = $head->child_get_string( "env-failed-fan-count" );
-                my $node_name = $head->child_get_string( "node" );
+            if ($failed_fan_count) {
+                $sum_failed_fan++;
 
-                if ($failed_fan_count) {
-                    $sum_failed_fan++;
-
-                    if ($failed_node) {
-                        $failed_node .= ", $node_name";
-                    } else {
-                        $failed_node .= $node_name;
-                    }
+                if ($failed_node) {
+                    $failed_node .= ", $node_name";
+                } else {
+                    $failed_node .= $node_name;
                 }
             }
         }
+    }
+    elsif ($Plugin eq "nvram") {
+        foreach my $head (@result) {
+            my $nvram_status = $head->child_get_string( "nvram-battery-status" );
+            my $node_name = $head->child_get_string( "node" );
+            if ($head->child_get_string( "is-node-healthy" ) eq "true") {
+                $sum_failed_nvram++ if $nvram_status ne "battery_ok";
 
-        when("nvram") {
-            foreach my $head (@result) {
-                my $nvram_status = $head->child_get_string( "nvram-battery-status" );
-                my $node_name = $head->child_get_string( "node" );
-                if ($head->child_get_string( "is-node-healthy" ) eq "true") {
-                    $sum_failed_nvram++ if $nvram_status ne "battery_ok";
-
-                    if ($failed_node) {
-                        $failed_node .= ", $node_name";
-                    } else {
-                        $failed_node .= $node_name;
-                    }
+                if ($failed_node) {
+                    $failed_node .= ", $node_name";
+                } else {
+                    $failed_node .= $node_name;
                 }
             }
         }
+    }
+    elsif ($Plugin eq "temp") {
+        foreach my $head (@result) {
+            my $temp_status = $head->child_get_string( "env-over-temperature" );
+            my $node_name = $head->child_get_string( "node" );
+            if ($head->child_get_string( "is-node-healthy" ) eq "true") {
+                $sum_failed_temp++ if $temp_status ne "false";
 
-        when("temp") {
-            foreach my $head (@result) {
-                my $temp_status = $head->child_get_string( "env-over-temperature" );
-                my $node_name = $head->child_get_string( "node" );
-                if ($head->child_get_string( "is-node-healthy" ) eq "true") {
-                    $sum_failed_temp++ if $temp_status ne "false";
-
-                    if ($failed_node) {
-                        $failed_node .= ", $node_name";
-                    } else {
-                        $failed_node .= $node_name;
-                    }
+                if ($failed_node) {
+                    $failed_node .= ", $node_name";
+                } else {
+                    $failed_node .= $node_name;
                 }
             }
         }
+    }
+    elsif ($Plugin eq "health") {
+        foreach my $head (@result) {
 
-        when("health") {
-            foreach my $head (@result) {
+            my $health_status = $head->child_get_string( "is-node-healthy" );
+            my $node_name = $head->child_get_string( "node" );
+            if ($health_status ne "true") {
+                $sum_failed_health++;
 
-                my $health_status = $head->child_get_string( "is-node-healthy" );
-                my $node_name = $head->child_get_string( "node" );
-                if ($health_status ne "true") {
-                    $sum_failed_health++;
-
-                    if ($failed_node) {
-                        $failed_node .= ", $node_name";
-                    } else {
-                        $failed_node .= $node_name;
-                    }
+                if ($failed_node) {
+                    $failed_node .= ", $node_name";
+                } else {
+                    $failed_node .= $node_name;
                 }
             }
         }
@@ -164,61 +155,54 @@ while(defined( $next )){
     $next = $output->child_get_string( "next-tag" );
 }
 
-given ($Plugin) {
-    when("power") {
-        if ($sum_failed_power) {
-            print "CRITICAL: $sum_failed_power failed power supplie(s): $failed_node\n";
-            exit 2;
-        } else {
-            print "OK: No failed power supplies\n";
-            exit 0;
-        }
+# Final checks and exit
+if ($Plugin eq "power") {
+    if ($sum_failed_power) {
+        print "CRITICAL: $sum_failed_power failed power supplie(s): $failed_node\n";
+        exit 2;
+    } else {
+        print "OK: No failed power supplies\n";
+        exit 0;
     }
-    when("fan") {
-        if ($sum_failed_fan) {
-            print "CRITICAL: $sum_failed_fan failed fan(s): $failed_node\n";
-            exit 2;
-        } else {
-            print "OK: No failed fans\n";
-            exit 0;
-        }
+}
+elsif ($Plugin eq "fan") {
+    if ($sum_failed_fan) {
+        print "CRITICAL: $sum_failed_fan failed fan(s): $failed_node\n";
+        exit 2;
+    } else {
+        print "OK: No failed fans\n";
+        exit 0;
     }
-    when("nvram") {
-        if ($sum_failed_nvram) {
-            print "CRITICAL: $sum_failed_nvram failed nvram(s): $failed_node\n";
-            exit 2;
-        } else {
-            print "OK: No failed nvram\n";
-            exit 0;
-        }
+}
+elsif ($Plugin eq "nvram") {
+    if ($sum_failed_nvram) {
+        print "CRITICAL: $sum_failed_nvram failed nvram(s): $failed_node\n";
+        exit 2;
+    } else {
+        print "OK: No failed nvram\n";
+        exit 0;
     }
-    when("temp") {
-        if ($sum_failed_temp) {
-            print "CRITICAL: Temperature Overheating: $failed_node\n";
-            exit 2;
-        } else {
-            print "OK: Temperature OK\n";
-            exit 0;
-        }
+}
+elsif ($Plugin eq "temp") {
+    if ($sum_failed_temp) {
+        print "CRITICAL: Temperature Overheating: $failed_node\n";
+        exit 2;
+    } else {
+        print "OK: Temperature OK\n";
+        exit 0;
     }
-    when("health") {
-        if ($sum_failed_health) {
-            print "CRITICAL: Health Status Critical: $failed_node\n";
-            exit 2;
-        } else {
-            print "OK: Health Status OK\n";
-            exit 0;
-        }
+}
+elsif ($Plugin eq "health") {
+    if ($sum_failed_health) {
+        print "CRITICAL: Health Status Critical: $failed_node\n";
+        exit 2;
+    } else {
+        print "OK: Health Status OK\n";
+        exit 0;
     }
 }
 
-__END__
-
-=encoding utf8
-
-=head1 NAME
-
-check_cdot_global.pl - Checks health status ( powersupplies, fans, ... )
+# check_cdot_global.pl - Checks health status ( powersupplies, fans, ... )
 
 =head1 SYNOPSIS
 

--- a/check_cdot_global.pl
+++ b/check_cdot_global.pl
@@ -18,6 +18,9 @@ use NaServer;
 use NaElement;
 use Getopt::Long qw(:config no_ignore_case);
 
+# ignore warning for experimental 'given'
+no if ($] >= 5.018), 'warnings' => 'experimental';
+
 GetOptions(
     'H|hostname=s' => \my $Hostname,
     'u|username=s' => \my $Username,
@@ -201,6 +204,12 @@ elsif ($Plugin eq "health") {
         exit 0;
     }
 }
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
 
 # check_cdot_global.pl - Checks health status ( powersupplies, fans, ... )
 

--- a/check_cdot_interfaces.pl
+++ b/check_cdot_interfaces.pl
@@ -22,11 +22,10 @@ use Getopt::Long;
 use Data::Dumper;
 
 GetOptions(
-    'hostname=s'  => \my $Hostname,
-    'username=s'  => \my $Username,
-    'password=s'  => \my $Password,
-    'crc-count:i' => \(my $CrcMaxCount = 10),
-    'help|?'      => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
+    'hostname=s' => \my $Hostname,
+    'username=s' => \my $Username,
+    'password=s' => \my $Password,
+    'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error( "$0: Error in command line arguments\n" );
 
 sub Error {
@@ -77,8 +76,8 @@ foreach my $head (@result) {
 
         if ($ifgrp_output->results_errno != 0) {
           my $r = $ifgrp_output->results_reason();
-        	print "UNKNOWN: $r\n";
-        	exit 3;
+                print "UNKNOWN: $r\n";
+                exit 3;
         }
     }
 
@@ -131,17 +130,21 @@ while(defined( $next )){
     if($lifs) {
 
         my @lif_result = $lifs->children_get();
-        
+
         foreach my $lif (@lif_result) {
-  
+
             my $node = $lif->child_get_string( "node" );
             my $name = $lif->child_get_string( "port" );
             my $state = $lif->child_get_string( "link-status" );
             my $admin_speed = $lif->child_get_string( "administrative-speed" );
             my $operational_speed = $lif->child_get_string( "operational-speed" );
+            my $port_type = $lif->child_get_string( "port-type" );
+
+            next if $port_type eq "vip"; # skip bgp ports
+            next if $port_type eq "vlan"; # skip vlan ports
 
             if($state eq "up"){
-                unless(($name =~ m/^a0/) || ($name =~ m/^e0M/)){ 
+                unless(($name =~ m/^a0/) || ($name =~ m/^e0M/)){
 
                     if(($admin_speed ne "auto") && ($admin_speed ne $operational_speed)){
                         push( @{$failed_speed{$node}}, $name);
@@ -216,7 +219,7 @@ if($nics) {
             $nic_name =~ s/kernel://;
 
             my ($node, $nic) = split( /:/, $nic_name );
-    
+
             unless( grep( /$nic/, @{$failed_ports{$node}} )) {
 
                 my $counters = $nic_element->child_get( "counters" );
@@ -225,11 +228,11 @@ if($nics) {
                     my @counter_result = $counters->children_get();
 
                     foreach my $counter (@counter_result) {
-                    
+
                         my $key = $counter->child_get_string( "name" );
                         my $value = $counter->child_get_string( "value" );
 
-                        if($value > $CrcMaxCount) {
+                        if($value > 10) {
                             push(@nic_errors, $nic_name);
                         }
                     }
@@ -326,4 +329,3 @@ to see this Documentation
 =head1 AUTHORS
 
  Alexander Krogloth <git at krogloth.de>
-

--- a/check_cdot_interfaces.pl
+++ b/check_cdot_interfaces.pl
@@ -25,6 +25,7 @@ GetOptions(
     'hostname=s' => \my $Hostname,
     'username=s' => \my $Username,
     'password=s' => \my $Password,
+    'crc-count:i' => \(my $CrcMaxCount = 10),
     'help|?'     => sub { exec perldoc => -F => $0 or die "Cannot execute perldoc: $!\n"; },
 ) or Error( "$0: Error in command line arguments\n" );
 
@@ -232,7 +233,7 @@ if($nics) {
                         my $key = $counter->child_get_string( "name" );
                         my $value = $counter->child_get_string( "value" );
 
-                        if($value > 10) {
+                        if($value > $CrcMaxCount) {
                             push(@nic_errors, $nic_name);
                         }
                     }

--- a/check_cdot_multipath.pl
+++ b/check_cdot_multipath.pl
@@ -135,7 +135,7 @@ while(defined( $next )){
             #
             my $disk_raid_info = $disk->child_get( "disk-raid-info");
             my $container_type = $disk_raid_info->child_get_string("container-type") // 'unknown';
-            next if $container_type ~~ @skipped_container_types;
+            next if grep { $_ eq $container_type } @skipped_container_types;
 
             #
             my $shelf = $inventory->child_get_string("shelf") // '0';


### PR DESCRIPTION
to be fair:
as I don't "speak" perl, I let CoPilot do the work.
But the scripts do still work and produce the same output (apart from the deprecation warnings) as before

<img width="603" height="340" alt="image" src="https://github.com/user-attachments/assets/a717e27a-1945-488a-b389-b3f429b876d3" />
<img width="384" height="173" alt="image" src="https://github.com/user-attachments/assets/43a5c554-9284-4f86-be7e-b48968aebf6b" />

<img width="1127" height="150" alt="image" src="https://github.com/user-attachments/assets/b0905a4c-f4af-47a8-aee6-7146c9012a45" />
<img width="1120" height="184" alt="image" src="https://github.com/user-attachments/assets/8ce5db24-99e3-42f0-b624-c4a636bef45e" />
